### PR TITLE
Use watson-developer-cloud instead of watson-developer-cloud-alpha

### DIFF
--- a/lib/doctor.js
+++ b/lib/doctor.js
@@ -1,4 +1,4 @@
-var watson = require('watson-developer-cloud-alpha'),
+var watson = require('watson-developer-cloud'),
   log = require('loglevel'),
   cfenv = require('cfenv');
 

--- a/lib/speech.js
+++ b/lib/speech.js
@@ -1,4 +1,4 @@
-var watson = require('watson-developer-cloud-alpha'),
+var watson = require('watson-developer-cloud'),
   request = require('request'),
   http = require('http'),
   fs = require('fs'),

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "sox": "^0.1.0",
     "tmp": "^0.0.24",
     "twilio": "^1.10.0",
-    "watson-developer-cloud-alpha": "^0.10.4"
+    "watson-developer-cloud": "^0.9.3"
   },
   "author": "James Thomas",
   "license": "MIT"


### PR DESCRIPTION
The `watson-developer-cloud-alpha` module is not recommended for production use. This pull request will switch the project to use the `watson-developer-cloud`